### PR TITLE
Fix phy groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "expipe>=0.6.0", 
     "neuroconv>=0.4.6",
     "pyopenephys>=1.2.0",
-    "spikeinterface[full,widgets]>=0.100.0",
+    "spikeinterface[full,widgets]>=0.100.0,<0.101.0",
     "scikit-learn<1.5.0",
     "pynwb>=2.5.0",
     "neuroconv>=0.4.6",

--- a/src/expipe_plugin_cinpla/scripts/curation.py
+++ b/src/expipe_plugin_cinpla/scripts/curation.py
@@ -147,9 +147,8 @@ class SortingCurator:
             print("Removing excess spikes from curated sorting")
             curated_sorting = sc.remove_excess_spikes(curated_sorting, recording=recording)
 
-            # if not sort by group, extract dense and estimate group
-            if "group" not in curated_sorting.get_property_keys():
-                compute_and_set_unit_groups(curated_sorting, recording)
+            # if "group" is not available or some missing groups, extract dense and estimate group
+            compute_and_set_unit_groups(curated_sorting, recording)
 
             print("Extracting waveforms on curated sorting")
             self.curated_we = si.extract_waveforms(


### PR DESCRIPTION
Fixes #79

@mariapfj

What this PR does is to look for "groups" which are "nan" (which is what is loaded when the group is missing) and recomputing the group from the template (taking the group from the channel with the largest amplitude).

Does that sound reasonable?