### PR TITLE
Fix formatting and linter errors from #94

### DIFF
--- a/src/expipe_plugin_cinpla/nwbutils/nwbwidgetsunitviewer.py
+++ b/src/expipe_plugin_cinpla/nwbutils/nwbwidgetsunitviewer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
+import warnings
 from functools import partial
 
-import warnings
 import ipywidgets as widgets
 import matplotlib.pyplot as plt
 import numpy as np
@@ -222,10 +222,12 @@ class UnitRateMapWidget(widgets.VBox):
 
     def compute_rate_maps(self):
         import pynapple as nap
+
         try:
             from spatial_maps import SpatialMap
+
             HAVE_SPATIAL_MAPS = True
-        except:
+        except ImportError:
             warnings.warn(
                 "spatial_maps not installed. Please install it to compute rate maps:\n"
                 ">>> pip install git+https://github.com/CINPLA/spatial-maps.git"

--- a/src/expipe_plugin_cinpla/tools/data_processing.py
+++ b/src/expipe_plugin_cinpla/tools/data_processing.py
@@ -15,6 +15,17 @@ from expipe_plugin_cinpla.data_loader import (
     load_spiketrains,
 )
 
+try:
+    import spatial_maps as sp
+
+    HAVE_SPATIAL_MAPS = True
+except ImportError:
+    warnings.warn(
+        "spatial_maps not installed. Please install it to compute rate maps:\n"
+        ">>> pip install git+https://github.com/CINPLA/spatial-maps.git"
+    )
+    HAVE_SPATIAL_MAPS = False
+
 
 def view_active_channels(action, sorter):
     path = action.data_path()


### PR DESCRIPTION
Fixes the formatting and linting errors introduced in https://github.com/CINPLA/expipe-plugin-cinpla/pull/94.

@alejoe91 Answering to https://github.com/CINPLA/expipe-plugin-cinpla/pull/94#issuecomment-2491027317; I get the same error as the CI about the formatting in `src/expipe_plugin_cinpla/nwbutils/nwbwidgetsunitviewer.py` locally both when I do a commit on that file (I just tried staging after adding a comment) or if run `pre-commit run --all-files`. The CI is prohibited from making changes to the code, but locally `pre-commit` fixes the black formatting automatically. 

Since `pre-commit` and `black` have minimal custom configurations in this project,  it's strange that `pre-commit` didn't stop your commit if you have the same `pre-commit` and `black` versions as the CI. I think we just have to see if this is a problem that persists, and if it does we have to dig deeper.

I also had to manually fix some linter errors.