### PR TITLE
Set number of jobs using SLURM env

### DIFF
--- a/src/expipe_plugin_cinpla/scripts/process.py
+++ b/src/expipe_plugin_cinpla/scripts/process.py
@@ -58,7 +58,10 @@ def process_ecephys(
     if nwb_path_tmp.is_file():
         nwb_path_tmp.unlink()
 
-    si.set_global_job_kwargs(n_jobs=-1, progress_bar=False)
+    # We need to use the number of allocated CPUs, if available
+    n_jobs = int(os.environ.get("SLURM_CPUS_ON_NODE", -1))
+    print("N JOBS", n_jobs)
+    si.set_global_job_kwargs(n_jobs=n_jobs, progress_bar=False)
 
     if overwrite:
         if verbose:


### PR DESCRIPTION
Fixes #108 

@mariapfj I found out that the number of CPUs requested by the user is in an env variable, so we can use it!